### PR TITLE
add netcoreapp3.0 target for .Net Core 3 compatibility

### DIFF
--- a/jsreport.AspNetCore/jsreport.AspNetCore.csproj
+++ b/jsreport.AspNetCore/jsreport.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <PackageId>jsreport.AspNetCore</PackageId>
     <Title>jsreport asp.net core and MVC integration</Title>
     <Authors>Jan Blaha</Authors>
@@ -20,9 +20,13 @@
     <AssemblyVersion>2.0.2.0</AssemblyVersion>
   </PropertyGroup>
 
-  <ItemGroup>    
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">    
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />    
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <Choose>


### PR DESCRIPTION
When using jsReport from an ASP.NET Core 3.0 application, I encountered a version conflict for the 'Microsoft.Extensions.DependencyModel' package.

Please consider this PR with the following changes for .Net Core 3 compatibility:

- add netcoreapp3.0 target
- add framework reference to 'Microsoft.AspNetCore.App'
